### PR TITLE
publish non-conflicting pypi names

### DIFF
--- a/packages/eth_rpc/pyproject.toml
+++ b/packages/eth_rpc/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=68", "setuptools_scm[toml]>=8"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "eth-rpc"
+name = "eth-rpc-py"
 requires-python = ">=3.10"
 dynamic = ["version"]
 dependencies = [

--- a/packages/eth_typeshed/pyproject.toml
+++ b/packages/eth_typeshed/pyproject.toml
@@ -3,11 +3,11 @@ requires = ["setuptools>=68", "setuptools_scm[toml]>=8"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "eth-typeshed"
+name = "eth-typeshed-py"
 requires-python = ">=3.10"
 dynamic = ["version"]
 dependencies = [
-    "eth_rpc",
+    "eth_rpc_py",
 ]
 
 # Enables the usage of setuptools_scm


### PR DESCRIPTION
there is a pypi conflict on the `eth-rpc` package name.
We could opt to eth-rpc-py 