### PR TITLE
Add EIP-7702 delegation utilities

### DIFF
--- a/packages/eth_rpc/src/eth_rpc/__init__.py
+++ b/packages/eth_rpc/src/eth_rpc/__init__.py
@@ -13,6 +13,7 @@ from .account import Account
 from .block import Block
 from .codegen import codegen
 from .contract import Contract, ContractFunc, EthResponse, FuncSignature, ProtocolBase
+from .delegation import create_authorization_item, prepare_delegation_transaction, sponsor_delegation
 from .event import Event
 from .log import Log
 from .models import EventData
@@ -47,12 +48,15 @@ __all__ = [
     "add_middleware",
     "codegen",
     "configure_rpc_from_env",
+    "create_authorization_item",
     "get_current_network",
     "get_selected_wallet",
+    "prepare_delegation_transaction",
     "set_alchemy_key",
     "set_default_network",
-    "set_selected_wallet",
-    "set_transport",
     "set_rpc_timeout",
     "set_rpc_url",
+    "set_selected_wallet",
+    "set_transport",
+    "sponsor_delegation",
 ]

--- a/packages/eth_rpc/src/eth_rpc/delegation.py
+++ b/packages/eth_rpc/src/eth_rpc/delegation.py
@@ -1,0 +1,135 @@
+from typing import Optional
+
+from eth_typing import HexAddress, HexStr
+from eth_account import Account as EthAccount
+
+from .types import HexInteger
+from .types.transaction import AuthorizationItem
+from .transaction import PreparedTransaction
+from .wallet import BaseWallet
+
+
+def create_authorization_item(
+    chain_id: int,
+    address: HexAddress,
+    nonce: int,
+    private_key: HexStr,
+) -> AuthorizationItem:
+    """
+    Create a signed authorization item for EIP-7702 delegation.
+
+    Args:
+        chain_id: The chain ID for the authorization
+        address: The address to authorize delegation to
+        nonce: The nonce for this authorization
+        private_key: Private key to sign the authorization
+
+    Returns:
+        Signed AuthorizationItem
+    """
+    auth = {
+        "chainId": chain_id,
+        "address": address,
+        "nonce": nonce,
+    }
+
+    account = EthAccount.from_key(private_key)
+    signed_auth = account.sign_authorization(auth)
+
+    return AuthorizationItem(
+        chain_id=HexInteger(chain_id),
+        address=address,
+        nonce=HexInteger(nonce),
+        y_parity=HexInteger(signed_auth.y_parity),
+        r=HexStr(hex(signed_auth.r)),
+        s=HexStr(hex(signed_auth.s)),
+    )
+
+
+def prepare_delegation_transaction(
+    wallet: BaseWallet,
+    to: HexAddress,
+    authorization_list: list[AuthorizationItem],
+    value: int = 0,
+    data: HexStr = HexStr("0x"),
+    gas: Optional[int] = None,
+    max_fee_per_gas: Optional[int] = None,
+    max_priority_fee_per_gas: Optional[int] = None,
+    nonce: Optional[int] = None,
+) -> PreparedTransaction:
+    """
+    Prepare an EIP-7702 delegation transaction.
+
+    Args:
+        wallet: Wallet to send the transaction from
+        to: Target address for the transaction
+        authorization_list: List of authorization items for delegation
+        value: ETH value to send (default: 0)
+        data: Transaction data (default: "0x")
+        gas: Gas limit (auto-estimated if None)
+        max_fee_per_gas: Maximum fee per gas
+        max_priority_fee_per_gas: Maximum priority fee per gas
+        nonce: Transaction nonce (auto-determined if None)
+
+    Returns:
+        PreparedTransaction with type 4 and authorization list
+    """
+    base_tx = wallet.prepare(
+        to=to,
+        value=value,
+        data=data,
+        max_fee_per_gas=max_fee_per_gas,
+        max_priority_fee_per_gas=max_priority_fee_per_gas,
+        nonce=nonce,
+    )
+
+    if gas is not None:
+        base_tx.gas = gas
+
+    base_tx.authorization_list = authorization_list
+    base_tx.type = 4
+
+    return base_tx
+
+
+def sponsor_delegation(
+    sponsor_wallet: BaseWallet,
+    delegatee_address: HexAddress,
+    delegatee_private_key: HexStr,
+    target_address: HexAddress,
+    chain_id: int,
+    nonce: int,
+    value: int = 0,
+    data: HexStr = HexStr("0x"),
+) -> PreparedTransaction:
+    """
+    Create a sponsored delegation transaction where the sponsor pays gas
+    for a delegated call from the delegatee.
+
+    Args:
+        sponsor_wallet: Wallet that will pay for gas
+        delegatee_address: Address that will be delegated to
+        delegatee_private_key: Private key of delegatee to sign authorization
+        target_address: Target address for the delegated call
+        chain_id: Chain ID for the authorization
+        nonce: Nonce for the authorization
+        value: ETH value to send
+        data: Transaction data
+
+    Returns:
+        PreparedTransaction ready to be signed by sponsor
+    """
+    auth_item = create_authorization_item(
+        chain_id=chain_id,
+        address=delegatee_address,
+        nonce=nonce,
+        private_key=delegatee_private_key,
+    )
+
+    return prepare_delegation_transaction(
+        wallet=sponsor_wallet,
+        to=target_address,
+        authorization_list=[auth_item],
+        value=value,
+        data=data,
+    )

--- a/packages/eth_rpc/src/eth_rpc/models/transaction.py
+++ b/packages/eth_rpc/src/eth_rpc/models/transaction.py
@@ -1,6 +1,7 @@
 from typing import Optional
 
 from eth_rpc.types import HexInteger
+from eth_rpc.types.transaction import AuthorizationItem
 from eth_typing import HexStr
 from pydantic import BaseModel, ConfigDict, Field
 from pydantic.alias_generators import to_camel
@@ -17,6 +18,7 @@ class BaseTransaction(BaseModel):
 
     hash: HexStr
     access_list: Optional[list[AccessList]] = None
+    authorization_list: Optional[list[AuthorizationItem]] = None
     chain_id: Optional[HexInteger] = None
     from_: HexStr = Field(alias="from")
     gas: HexInteger

--- a/packages/eth_rpc/src/eth_rpc/transaction.py
+++ b/packages/eth_rpc/src/eth_rpc/transaction.py
@@ -7,6 +7,7 @@ from typing import Generic, Optional, cast
 from eth_rpc.models import AccessList, PendingTransaction
 from eth_rpc.models import Transaction as TransactionModel
 from eth_rpc.models import TransactionReceipt as TransactionReceiptModel
+from eth_rpc.types.transaction import AuthorizationItem
 from eth_rpc.types.args import (
     GetTransactionByBlockHash,
     GetTransactionByBlockNumber,
@@ -55,6 +56,7 @@ class PreparedTransaction(BaseModel):
     to: HexAddress
     value: int
     access_list: Optional[list[AccessList]] = None
+    authorization_list: Optional[list[AuthorizationItem]] = None
     chain_id: int
 
     def model_dump(self, *args, exclude_none=True, by_alias=True, **kwargs):
@@ -64,7 +66,9 @@ class PreparedTransaction(BaseModel):
 
     @model_validator(mode="after")
     def validate_xor(self):
-        if self.max_fee_per_gas is not None:
+        if self.authorization_list is not None:
+            self.type = 4
+        elif self.max_fee_per_gas is not None:
             self.type = 2
         else:
             self.type = 1

--- a/packages/eth_rpc/src/eth_rpc/types/transaction.py
+++ b/packages/eth_rpc/src/eth_rpc/types/transaction.py
@@ -1,5 +1,23 @@
-from eth_typing import HexStr
-from pydantic import BaseModel
+from eth_typing import HexAddress, HexStr
+from pydantic import BaseModel, ConfigDict
+from pydantic.alias_generators import to_camel
+
+from . import HexInteger
+
+
+class AuthorizationItem(BaseModel):
+    model_config = ConfigDict(
+        alias_generator=to_camel,
+        populate_by_name=True,
+        from_attributes=True,
+    )
+
+    chain_id: HexInteger
+    address: HexAddress
+    nonce: HexInteger
+    y_parity: HexInteger
+    r: HexStr
+    s: HexStr
 
 
 class SignedTransaction(BaseModel):


### PR DESCRIPTION
- Add AuthorizationItem model for delegation authorization lists
- Extend PreparedTransaction and BaseTransaction to support type 4 transactions
- Create delegation utilities for easy sponsorship of delegated transactions
- Add helper functions for creating authorization items and preparing delegation transactions

Implements EIP-7702 account delegation with utilities similar to web3.py patterns but implemented natively in eth_rpc. Includes create_authorization_item, prepare_delegation_transaction, and sponsor_delegation functions.